### PR TITLE
TeleportManager.java: Fix sendPlayerToLastBack

### DIFF
--- a/src/main/java/com/minecraftdimensions/bungeesuite/managers/TeleportManager.java
+++ b/src/main/java/com/minecraftdimensions/bungeesuite/managers/TeleportManager.java
@@ -183,7 +183,7 @@ public class TeleportManager {
         } else if ( death ) {
             teleportPlayerToLocation( player, player.getDeathBackLocation() );
         } else if ( teleport ) {
-            teleportPlayerToLocation( player, player.getDeathBackLocation() );
+            teleportPlayerToLocation( player, player.getTeleportBackLocation() );
         }
     }
 


### PR DESCRIPTION
Fixes /back not working properly for users who have the permission to /back on teleport but not on death.
